### PR TITLE
Check for existing properties and events.

### DIFF
--- a/lib/Exml.Validator.cs
+++ b/lib/Exml.Validator.cs
@@ -63,6 +63,7 @@ public static class ExmlValidator
                                 while (reader.MoveToNextAttribute())
                                 {
                                     var attributeIssues = current.AddAttribute(reader.Name, reader.Value);
+                                    attributeIssues.ForEach(issue => issue.AddContext(reader as IXmlLineInfo));
                                     issues.AddRange(attributeIssues);
                                 }
                                 reader.MoveToElement();

--- a/lib/Exml.XmlModel.cs
+++ b/lib/Exml.XmlModel.cs
@@ -126,9 +126,17 @@ public class Widget
                                                                   ValidatorModel.ValidationIssueSeverity.Error));
                 }
             }
+            else
+            {
+                if (!prop.HasSet)
+                {
+                    issues.Add(new ValidatorModel.ValidationIssue($"Property \"{attrName.Substring(prefix.Length)}\" is not writeable",
+                                                                  "",
+                                                                  ValidatorModel.ValidationIssueSeverity.Error));
+                }
+            }
             // TODO: Actually store this property somewhere and its value for code generation.
 
-            // TODO: Rule: Is the property writable?
             // TODO: Rule: Is the value acceptable for the property?
         }
 

--- a/test/Exml.Validator.Test.cs
+++ b/test/Exml.Validator.Test.cs
@@ -83,6 +83,21 @@ namespace TestSuite
             Test.AssertEquals(issue.Message, "Event \"wtfEvt\" does not exist in \"Button\"");
         }
 
+        public static void read_only_property(string test_folder)
+        {
+            var issues = ExmlValidator.Validate(Path.Combine(test_folder, "read_only_property.xml"));
+
+            Test.AssertEquals(issues.Count, 1);
+
+            var issue = issues[0];
+            Console.WriteLine($"Issue {issue}");
+            Test.AssertEquals(issue.Severity, ValidationIssueSeverity.Error);
+            Test.AssertEquals(issue.Line, 4);
+            Test.AssertEquals(issue.Position, 17);
+            Test.AssertEquals(issue.Message, "Property \"invalidated\" is not writeable");
+
+        }
+
     }
 }
 

--- a/test/Exml.Validator.Test.cs
+++ b/test/Exml.Validator.Test.cs
@@ -62,6 +62,27 @@ namespace TestSuite
             Test.AssertEquals(issue.Message, "Type Button is not a container");
         }
 
+        public static void non_existent_properties(string test_folder)
+        {
+            var issues = ExmlValidator.Validate(Path.Combine(test_folder, "non_existent_members.xml"));
+
+            Test.AssertEquals(issues.Count, 2);
+
+            // Property issue
+            var issue = issues[0];
+            Test.AssertEquals(issue.Severity, ValidationIssueSeverity.Error);
+            Test.AssertEquals(issue.Line, 5);
+            Test.AssertEquals(issue.Position, 17);
+            Test.AssertEquals(issue.Message, "Property \"nontext\" does not exist in \"Button\"");
+
+            // Event issue
+            issue = issues[1];
+            Test.AssertEquals(issue.Severity, ValidationIssueSeverity.Error);
+            Test.AssertEquals(issue.Line, 5);
+            Test.AssertEquals(issue.Position, 38);
+            Test.AssertEquals(issue.Message, "Event \"wtfEvt\" does not exist in \"Button\"");
+        }
+
     }
 }
 

--- a/test/samples/invalid_xml.xml
+++ b/test/samples/invalid_xml.xml
@@ -5,5 +5,5 @@
         <Button efl:text="Cancel" />
         <!-- The tag below should be invalidated as the RangeValue property of
         Efl.Ui.Spin is a double. !-->
-        <Spin efl:range_value="Hello" />
+        <Spin efl:rangeValue="Hello" />
 </exml>

--- a/test/samples/non_existent_members.xml
+++ b/test/samples/non_existent_members.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <exml xmlns:efl="http://www.enlightenment.org/EXML">
-<Button>
+<Box efl:orientation="Vertical">
         <Button efl:text="Ok" />
-        <Button efl:text="Cancel" />
-</Button>
+        <Button efl:nontext="Cancel" efl:wtfEvt="SomeCallback"/>
+</Box>
 </exml>

--- a/test/samples/read_only_property.xml
+++ b/test/samples/read_only_property.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<exml xmlns:efl="http://www.enlightenment.org/EXML">
+<Box efl:orientation="Vertical">
+        <Button efl:invalidated="true" />
+</Box>
+</exml>


### PR DESCRIPTION
In case a property "Foo" does not exist as a C#-style property, we check
if a "SetFoo" method with a single parameter is available. This is
needed due to some essential properties being blacklisted in EFL# like
Efl.IText.Text (due to clash with Efl.Ui.Text constructor)

Fixes #9

Also updated some examples that would raise issues in other tests.