### PR TITLE
Save attributes and check properties for issues in the value format

### DIFF
--- a/lib/Exml.ApiModel.cs
+++ b/lib/Exml.ApiModel.cs
@@ -38,11 +38,13 @@ namespace ApiModel
     {
         public string Name { get; private set; }
         public bool IsReference { get; private set; }
+        public System.Type AssemblyType { get; private set; }
 
         public static TypeRef From(System.Type type)
         {
             var obj = new TypeRef();
             obj.Name = type.FullName;
+            obj.AssemblyType = type;
 
             obj.IsReference = type.IsByRef;
 
@@ -300,7 +302,7 @@ namespace ApiModel
             obj.Name = type.FullName;
 
             var fields = type.GetFields(BindingFlags.Public | BindingFlags.Instance);
-
+            obj.Fields.Capacity = fields.Length;
             foreach(var field in fields)
             {
                 obj.Fields.Add(StructField.From(field));
@@ -451,19 +453,25 @@ namespace ApiModel
                 obj.Parent = TypeRef.From(type.BaseType);
             }
 
-            foreach(var iface in type.GetInterfaces())
+            var ifaces = type.GetInterfaces();
+            obj.Interfaces.Capacity = ifaces.Length;
+            foreach(var iface in ifaces)
             {
                 obj.Interfaces.Add(TypeRef.From(iface));
             }
 
             // No to pass BindingFlags, already gets only the public constructors by default
-            foreach(var ctor in type.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
+            var ctors = type.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            obj.Constructors.Capacity = ctors.Length;
+            foreach(var ctor in ctors)
             {
                 obj.Constructors.Add(Function.From(ctor));
             }
 
             // FIXME Do we need to list static methods too?
-            foreach(var method in type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
+            var methods = type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            obj.Methods.Capacity = methods.Length;
+            foreach(var method in methods)
             {
                 // Skip anonymous property accessors (get_Name)
                 if (!method.IsSpecialName)
@@ -472,12 +480,16 @@ namespace ApiModel
                 }
             }
 
-            foreach(var property in type.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
+            var properties = type.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            obj.Properties.Capacity = properties.Length;
+            foreach(var property in properties)
             {
                 obj.Properties.Add(Property.From(property));
             }
 
-            foreach (var evt in type.GetEvents(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
+            var events = type.GetEvents(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            obj.Events.Capacity = events.Length;
+            foreach (var evt in events)
             {
                 obj.Events.Add(Event.From(evt));
             }

--- a/test/Exml.Validator.Test.cs
+++ b/test/Exml.Validator.Test.cs
@@ -28,7 +28,7 @@ namespace TestSuite
             var issue = issues[0];
 
             Test.AssertEquals(issue.Severity, ValidationIssueSeverity.CriticalError);
-            Test.AssertEquals(issue.Line, 9);
+            Test.AssertEquals(issue.Line, 6);
             Test.AssertEquals(issue.Position, 3);
         }
 
@@ -96,6 +96,25 @@ namespace TestSuite
             Test.AssertEquals(issue.Position, 17);
             Test.AssertEquals(issue.Message, "Property \"invalidated\" is not writeable");
 
+        }
+
+        public static void property_invalid_value_format(string test_folder)
+        {
+            var issues = ExmlValidator.Validate(Path.Combine(test_folder, "invalid_property_value.xml"));
+
+            Test.AssertEquals(issues.Count, 2);
+
+            var issue = issues[0];
+            Test.AssertEquals(issue.Severity, ValidationIssueSeverity.Error);
+            Test.AssertEquals(issue.Line, 8);
+            Test.AssertEquals(issue.Position, 15);
+            Test.AssertEquals(issue.Message, "\"Hello\" is not a valid value for property \"efl:rangeValue\" of type \"System.Double\"");
+
+            issue = issues[1];
+            Test.AssertEquals(issue.Severity, ValidationIssueSeverity.Error);
+            Test.AssertEquals(issue.Line, 9);
+            Test.AssertEquals(issue.Position, 15);
+            Test.AssertEquals(issue.Message, "\"3.3.3\" is not a valid value for property \"efl:rangeValue\" of type \"System.Double\"");
         }
 
     }

--- a/test/samples/invalid_property_value.xml
+++ b/test/samples/invalid_property_value.xml
@@ -5,6 +5,7 @@
         <Button efl:text="Cancel" />
         <!-- The tag below should be invalidated as the RangeValue property of
         Efl.Ui.Spin is a double. !-->
-        <Spin efl:range_value="Hello" />
+        <Spin efl:rangeValue="Hello" />
+        <Spin efl:rangeValue="3.3.3" />
 </Box>
 </exml>

--- a/test/samples/invalid_xml.xml
+++ b/test/samples/invalid_xml.xml
@@ -3,7 +3,4 @@
 <Box efl:orientation="Vertical">
         <Button efl:text="Ok" />
         <Button efl:text="Cancel" />
-        <!-- The tag below should be invalidated as the RangeValue property of
-        Efl.Ui.Spin is a double. !-->
-        <Spin efl:rangeValue="Hello" />
 </exml>


### PR DESCRIPTION
Saving added attributes in the Attributes property.
Check properties for valid values.
Properties that receive numeric, boolean or char values are checked for
consistency using the C# native `Parse` methods.

Also add some changes in DLL parsing:
- save System.Type inside ApiModel.TypeRef,
- preallocate memory in lists when parsing to save resources.

Fixes #11